### PR TITLE
Add ffaker dependency to gemspec

### DIFF
--- a/solidus_expedited_exchanges.gemspec
+++ b/solidus_expedited_exchanges.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'timecop'
+  s.add_development_dependency 'ffaker'
 end


### PR DESCRIPTION
ffaker was removed as a runtime dependency of Solidus here:
https://github.com/solidusio/solidus/pull/2163