### PR TITLE
Add support for Solidus 2.5

### DIFF
--- a/lib/tasks/exchanges.rake
+++ b/lib/tasks/exchanges.rake
@@ -9,7 +9,7 @@ namespace :exchanges do
 
     # Determine that a return item has already been deemed unreturned and therefore charged
     # by the fact that its exchange inventory unit has popped off to a different order
-    unreturned_return_items.select! { |ri| ri.inventory_unit.order_id == ri.exchange_inventory_unit.order_id }
+    unreturned_return_items.select! { |ri| ri.inventory_unit.order.id == ri.exchange_inventory_unit.order.id }
 
     failures = []
 


### PR DESCRIPTION
Do not assign order_id on inventory units anymore.`order_id` column has been removed from solidus since solidusio/solidus#2377. Now the order reference will be taken from the shipment in which the  inventory units are included.