### PR TITLE
Fix factory girl dependency for Solidus < 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,19 @@ else
   gem 'rails', '~> 5.0.0'
 end
 
-gem 'mysql2'
-gem 'pg'
+if ENV['DB'] == 'mysql'
+  gem 'mysql2'
+else
+  gem 'pg'
+end
+
+group :test do
+  gem 'rails-controller-testing'
+  if branch < "v2.5"
+    gem 'factory_bot', '4.10.0'
+  else
+    gem 'factory_bot', '> 4.10.0'
+  end
+end
 
 gemspec


### PR DESCRIPTION
We need to load a factory_bot version that has factory_girl in it
to support Solidus versions < 2.5

This change also includes conditional logic for the database
interface gems.