### PR TITLE
Request `trusty` distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 cache: bundler
 language: ruby
 rvm:


### PR DESCRIPTION
This seems to fix the default absence of Mysql and Postgresql servers.